### PR TITLE
feat(feed): implement OnAnswer Callback

### DIFF
--- a/pallet-chainlink-feed/Cargo.toml
+++ b/pallet-chainlink-feed/Cargo.toml
@@ -24,7 +24,7 @@ sp-runtime = { git = 'https://github.com/paritytech/substrate.git', branch = 'ro
 frame-support = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'rococo-v1', version = '3.0.0'}
 # `system` module provides us with all sorts of useful stuff and macros depend on it being around.
 frame-system = { git = 'https://github.com/paritytech/substrate.git', branch = 'rococo-v1', version = '3.0.0', default-features = false }
-frame-benchmarking = { default-features = false, git = 'https://github.com/paritytech/substrate.git', version = "3.0.0", optional = true }
+frame-benchmarking = { default-features = false, git = 'https://github.com/paritytech/substrate.git', branch = 'rococo-v1', version = "3.0.0", optional = true }
 
 [dev-dependencies]
 sp-std = { git = 'https://github.com/paritytech/substrate.git', branch = 'rococo-v1', version = '3.0.0' }

--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -286,7 +286,7 @@ pub mod pallet {
 		/// Number of rounds to keep around per feed.
 		type PruningWindow: Get<RoundId>;
 
-		/// Callback in `submit`
+		/// This callback will trigger when the round answer updates
 		type OnAnswerHandler: OnAnswerHandler<Self>;
 
 		/// The weight for this pallet's extrinsics.
@@ -433,6 +433,13 @@ pub mod pallet {
 		FeedCreator(T::AccountId),
 		/// The account is no longer allowed to create feeds. \[previously_creator\]
 		FeedCreatorRemoved(T::AccountId),
+		#[cfg(test)]
+		/// New round data
+		///
+		/// Note:
+		///
+		/// This is only for tests
+		NewData(T::FeedId, RoundData<T::BlockNumber, T::Value>),
 	}
 
 	#[pallet::error]

--- a/pallet-chainlink-feed/src/lib.rs
+++ b/pallet-chainlink-feed/src/lib.rs
@@ -530,8 +530,6 @@ pub mod pallet {
 		InvalidRound,
 		/// The calling account is not allowed to create feeds.
 		NotFeedCreator,
-		/// Round data conversion failed
-		RoundConversion,
 	}
 
 	#[pallet::hooks]

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -93,6 +93,12 @@ parameter_types! {
 type FeedId = u16;
 type Value = u64;
 
+impl pallet_chainlink_feed::traits::OnAnswerHandler<Test> for Test {
+	fn on_answer(feed: FeedId, new_data: RoundData<BlockNumber, Value>) {
+		ChainlinkFeed::deposit_event(pallet_chainlink_feed::Event::NewData(feed, new_data));
+	}
+}
+
 impl pallet_chainlink_feed::Config for Test {
 	type Event = Event;
 	type FeedId = FeedId;
@@ -101,7 +107,7 @@ impl pallet_chainlink_feed::Config for Test {
 	type PalletId = FeedPalletId;
 	type MinimumReserve = MinimumReserve;
 	type StringLimit = StringLimit;
-	type OnAnswerHandler = ();
+	type OnAnswerHandler = Self;
 	type OracleCountLimit = OracleLimit;
 	type FeedLimit = FeedLimit;
 	type PruningWindow = PruningWindow;

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -79,6 +79,21 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 
+/// A dimmy struct with trait `OnAnswerHandler`
+pub struct OnAnswerHandler;
+
+impl pallet_chainlink_feed::traits::OnAnswerHandler<Test> for OnAnswerHandler {
+	fn on_answer(
+		_feed: <Test as pallet_chainlink_feed::Config>::FeedId,
+		_new_data: pallet_chainlink_feed::Round<
+			<Test as frame_system::Config>::BlockNumber,
+			<Test as pallet_chainlink_feed::Config>::Value,
+		>,
+	) {
+		// do_nothing
+	}
+}
+
 pub(crate) const MIN_RESERVE: u64 = 100;
 
 parameter_types! {
@@ -101,6 +116,7 @@ impl pallet_chainlink_feed::Config for Test {
 	type PalletId = FeedPalletId;
 	type MinimumReserve = MinimumReserve;
 	type StringLimit = StringLimit;
+	type OnAnswerHandler = OnAnswerHandler;
 	type OracleCountLimit = OracleLimit;
 	type FeedLimit = FeedLimit;
 	type PruningWindow = PruningWindow;

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -79,21 +79,6 @@ impl pallet_balances::Config for Test {
 	type WeightInfo = ();
 }
 
-/// A dimmy struct with trait `OnAnswerHandler`
-pub struct OnAnswerHandler;
-
-impl pallet_chainlink_feed::traits::OnAnswerHandler<Test> for OnAnswerHandler {
-	fn on_answer(
-		_feed: <Test as pallet_chainlink_feed::Config>::FeedId,
-		_new_data: pallet_chainlink_feed::Round<
-			<Test as frame_system::Config>::BlockNumber,
-			<Test as pallet_chainlink_feed::Config>::Value,
-		>,
-	) {
-		// do_nothing
-	}
-}
-
 pub(crate) const MIN_RESERVE: u64 = 100;
 
 parameter_types! {
@@ -116,7 +101,7 @@ impl pallet_chainlink_feed::Config for Test {
 	type PalletId = FeedPalletId;
 	type MinimumReserve = MinimumReserve;
 	type StringLimit = StringLimit;
-	type OnAnswerHandler = OnAnswerHandler;
+	type OnAnswerHandler = ();
 	type OracleCountLimit = OracleLimit;
 	type FeedLimit = FeedLimit;
 	type PruningWindow = PruningWindow;

--- a/pallet-chainlink-feed/src/traits.rs
+++ b/pallet-chainlink-feed/src/traits.rs
@@ -1,6 +1,7 @@
 //! Traits
 use crate::{Config, RoundData};
 
+/// This implementation wille be as a callback when the round answer updates
 pub trait OnAnswerHandler<T: Config> {
 	fn on_answer(feed: T::FeedId, new_data: RoundData<T::BlockNumber, T::Value>);
 }

--- a/pallet-chainlink-feed/src/traits.rs
+++ b/pallet-chainlink-feed/src/traits.rs
@@ -1,10 +1,12 @@
 //! Traits
 use crate::{Config, Round};
 
-/// Callback while submiting a new value
 pub trait OnAnswerHandler<T: Config> {
-	/// This callback will be called in call `pallet_chainlink_feed::Call::submit`
-	fn on_answer(feed: T::FeedId, new_data: Round<T::BlockNumber, T::Value>)
-	where
-		Self: Sized;
+	fn on_answer(feed: T::FeedId, new_data: Round<T::BlockNumber, T::Value>);
+}
+
+impl<T: Config> OnAnswerHandler<T> for () {
+	fn on_answer(_feed: T::FeedId, _new_data: Round<T::BlockNumber, T::Value>) {
+		// do_nothing
+	}
 }

--- a/pallet-chainlink-feed/src/traits.rs
+++ b/pallet-chainlink-feed/src/traits.rs
@@ -1,12 +1,12 @@
 //! Traits
-use crate::{Config, Round};
+use crate::{Config, RoundData};
 
 pub trait OnAnswerHandler<T: Config> {
-	fn on_answer(feed: T::FeedId, new_data: Round<T::BlockNumber, T::Value>);
+	fn on_answer(feed: T::FeedId, new_data: RoundData<T::BlockNumber, T::Value>);
 }
 
 impl<T: Config> OnAnswerHandler<T> for () {
-	fn on_answer(_feed: T::FeedId, _new_data: Round<T::BlockNumber, T::Value>) {
+	fn on_answer(_feed: T::FeedId, _new_data: RoundData<T::BlockNumber, T::Value>) {
 		// do_nothing
 	}
 }

--- a/pallet-chainlink-feed/src/traits.rs
+++ b/pallet-chainlink-feed/src/traits.rs
@@ -1,0 +1,10 @@
+//! Traits
+use crate::{Config, Round};
+
+/// Callback while submiting a new value
+pub trait OnAnswerHandler<T: Config> {
+	/// This callback will be called in call `pallet_chainlink_feed::Call::submit`
+	fn on_answer(feed: T::FeedId, new_data: Round<T::BlockNumber, T::Value>)
+	where
+		Self: Sized;
+}

--- a/substrate-node-example/runtime/src/lib.rs
+++ b/substrate-node-example/runtime/src/lib.rs
@@ -280,6 +280,20 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
+pub struct OnAnswerHandler;
+
+impl pallet_chainlink_feed::traits::OnAnswerHandler<Runtime> for OnAnswerHandler {
+	fn on_answer(
+		_feed: <Runtime as pallet_chainlink_feed::Config>::FeedId,
+		_new_data: pallet_chainlink_feed::Round<
+			    <Runtime as frame_system::Config>::BlockNumber,
+			<Runtime as pallet_chainlink_feed::Config>::Value,
+		    >,
+	) {
+		// do_nothing
+	}
+}
+
 pub type FeedId = u32;
 pub type Value = u128;
 
@@ -300,6 +314,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 	type PalletId = FeedPalletId;
 	type MinimumReserve = MinimumReserve;
 	type StringLimit = StringLimit;
+    type OnAnswerHandler = OnAnswerHandler;
 	type OracleCountLimit = OracleCountLimit;
 	type FeedLimit = FeedLimit;
 	type PruningWindow = PruningWindow;

--- a/substrate-node-example/runtime/src/lib.rs
+++ b/substrate-node-example/runtime/src/lib.rs
@@ -280,20 +280,6 @@ impl pallet_sudo::Config for Runtime {
 	type Call = Call;
 }
 
-pub struct OnAnswerHandler;
-
-impl pallet_chainlink_feed::traits::OnAnswerHandler<Runtime> for OnAnswerHandler {
-	fn on_answer(
-		_feed: <Runtime as pallet_chainlink_feed::Config>::FeedId,
-		_new_data: pallet_chainlink_feed::Round<
-			    <Runtime as frame_system::Config>::BlockNumber,
-			<Runtime as pallet_chainlink_feed::Config>::Value,
-		    >,
-	) {
-		// do_nothing
-	}
-}
-
 pub type FeedId = u32;
 pub type Value = u128;
 
@@ -314,7 +300,7 @@ impl pallet_chainlink_feed::Config for Runtime {
 	type PalletId = FeedPalletId;
 	type MinimumReserve = MinimumReserve;
 	type StringLimit = StringLimit;
-    type OnAnswerHandler = OnAnswerHandler;
+    type OnAnswerHandler = ();
 	type OracleCountLimit = OracleCountLimit;
 	type FeedLimit = FeedLimit;
 	type PruningWindow = PruningWindow;


### PR DESCRIPTION
> The price of the underlying assets in the index must be up to date when a user redeems their PINT for those underlying assets. Manual updates would leave a lot of room for price variation which could potentially be gamed. Although the council can update the NAV of SAFTs, this is the exception not the rule.
>
> * New data from the oracle can automatically adjust the index's NAV

## Changes

* Add `OnAnswer` in the `Config` of `pallet-chainlink-feed`

## Tests

```
cargo t --manifest-path pallet-chainlink-feed/Cargo.toml
cargo t --manifest-path substrate-node-template/Cargo.toml
```

## Issues

* Ref https://github.com/ChainSafe/PINT/issues/30

Closes #8 
