### PR TITLE
feat(feed): ensure mutating storage safely with #[require_transactional]

### DIFF
--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -219,3 +219,25 @@ pub fn new_test_ext() -> sp_io::TestExternalities {
 
 	t.into()
 }
+
+#[macro_export]
+macro_rules! tx_assert_ok {
+	($e:expr) => {
+		with_transaction_result(|| -> Result<(), ()> {
+			assert_ok!($e);
+			Ok(())
+		})
+		.unwrap();
+	};
+}
+
+// #[macro_export]
+// macro_rules! tx_assert_noop {
+// 	($l:expr, $r:expr) => {
+// 		with_transaction_result(|| -> Result<(), ()> {
+// 			assert_noop!($l, $r);
+// 			Ok(())
+// 		})
+// 		.unwrap();
+// 	};
+// }

--- a/pallet-chainlink-feed/src/mock.rs
+++ b/pallet-chainlink-feed/src/mock.rs
@@ -230,14 +230,3 @@ macro_rules! tx_assert_ok {
 		.unwrap();
 	};
 }
-
-// #[macro_export]
-// macro_rules! tx_assert_noop {
-// 	($l:expr, $r:expr) => {
-// 		with_transaction_result(|| -> Result<(), ()> {
-// 			assert_noop!($l, $r);
-// 			Ok(())
-// 		})
-// 		.unwrap();
-// 	};
-// }

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -1,8 +1,9 @@
 use super::*;
-use crate::{mock::*, Error};
-use frame_support::sp_runtime::traits::AccountIdConversion;
-use frame_support::traits::Currency;
-use frame_support::{assert_noop, assert_ok, sp_runtime::traits::Zero};
+use crate::{mock::*, utils::with_transaction_result, Error};
+use frame_support::{
+	assert_noop, assert_ok, sp_runtime::traits::AccountIdConversion, sp_runtime::traits::Zero,
+	traits::Currency,
+};
 
 type Balances = pallet_balances::Pallet<Test>;
 
@@ -424,7 +425,7 @@ fn change_oracles_should_work() {
 		);
 
 		{
-			assert_ok!(ChainlinkFeed::feed_mut(feed_id)
+			tx_assert_ok!(ChainlinkFeed::feed_mut(feed_id)
 				.unwrap()
 				.request_new_round(AccountId::default()));
 		}
@@ -582,7 +583,7 @@ fn update_future_rounds_should_work() {
 		);
 
 		// successful update
-		assert_ok!(ChainlinkFeed::update_future_rounds(
+		tx_assert_ok!(ChainlinkFeed::update_future_rounds(
 			Origin::signed(owner),
 			feed_id,
 			new_payment,
@@ -891,7 +892,7 @@ fn feed_oracle_trait_should_work() {
 				}
 			);
 
-			assert_ok!(feed.request_new_round(AccountId::default()));
+			tx_assert_ok!(feed.request_new_round(AccountId::default()));
 		}
 		let round_id = 2;
 		let round =
@@ -1210,8 +1211,8 @@ fn feed_life_cylce() {
 		let oracles = vec![(2, 2), (3, 3), (4, 4)];
 		{
 			let mut feed = Feed::<Test>::new(id, new_config.clone());
-			assert_ok!(feed.add_oracles(oracles.clone()));
-			assert_ok!(feed.update_future_rounds(
+			tx_assert_ok!(feed.add_oracles(oracles.clone()));
+			tx_assert_ok!(feed.update_future_rounds(
 				payment,
 				submission_count_bounds,
 				restart_delay,
@@ -1250,8 +1251,13 @@ fn feed_life_cylce() {
 		);
 		{
 			let mut feed = ChainlinkFeed::feed_mut(id).expect("feed should be there");
-			assert_ok!(feed.request_new_round(AccountId::default()));
+			tx_assert_ok!(feed.request_new_round(AccountId::default()));
 		}
 		assert_eq!(ChainlinkFeed::feed_config(id).unwrap().reporting_round, 1);
 	});
+}
+
+#[test]
+fn check_require_transactional_works() {
+	new_test_ext().execute_with(|| {})
 }

--- a/pallet-chainlink-feed/src/tests.rs
+++ b/pallet-chainlink-feed/src/tests.rs
@@ -1256,8 +1256,3 @@ fn feed_life_cylce() {
 		assert_eq!(ChainlinkFeed::feed_config(id).unwrap().reporting_round, 1);
 	});
 }
-
-#[test]
-fn check_require_transactional_works() {
-	new_test_ext().execute_with(|| {})
-}


### PR DESCRIPTION
## Changes

Remove **Warning** annotations and append `#[require_transactional]` to mutating fallible functions

## Tests

```
$ cargo t --manifest-path pallet-chainlink-feed/Cargo.toml
```


## Issues

Closes #5